### PR TITLE
Restore section referring to hdf5 data path

### DIFF
--- a/nvidia-bert/README.md
+++ b/nvidia-bert/README.md
@@ -81,7 +81,12 @@ Note that the datasets used for BERT pre-training need a large amount of disk sp
 
 3. Make data accessible for training
 
-    Data prepared using the steps above need to be available for training. Follow instructions in the sections below to learn steps required for making data accessible to training process depending on the training environment.
+    After completing the steps above, data in hdf5 format will be available at the following locations: 
+
+    * Phase 1 data: `./workspace/BERT/data/hdf5_lower_case_1_seq_len_128_max_pred_20_masked_lm_prob_0.15_random_seed_12345_dupe_factor_5/wikicorpus_en/train`
+    * Phase 2 data: `./workspace/BERT/data/hdf5_lower_case_1_seq_len_512_max_pred_80_masked_lm_prob_0.15_random_seed_12345_dupe_factor_5/wikicorpus_en/train`
+
+    Below instructions refer to these hdf5 data files as the data to make accessible to training process.
 
 ## BERT pre-training with ONNX Runtime in Azure Machine Learning
 


### PR DESCRIPTION
This reduces the chance the user is confused what data the pretraining process expects and what corresponding paths to set.