### PR TITLE
Run apt-get update before installing build-essential

### DIFF
--- a/huggingface-gpt2/docker/Dockerfile
+++ b/huggingface-gpt2/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM mcr.microsoft.com/azureml/onnxruntime-training:0.1-rc2-openmpi4.0-cuda10.2-
 WORKDIR /workspace
 RUN python3 -m pip install azureml azureml-core
 COPY transformers/ transformers/
+RUN apt-get update
 RUN apt-get install -y build-essential
 RUN cd transformers/ && \
     python3 -m pip install --no-cache-dir . && \

--- a/huggingface-gpt2/docker/Dockerfile
+++ b/huggingface-gpt2/docker/Dockerfile
@@ -2,8 +2,8 @@ FROM mcr.microsoft.com/azureml/onnxruntime-training:0.1-rc2-openmpi4.0-cuda10.2-
 WORKDIR /workspace
 RUN python3 -m pip install azureml azureml-core
 COPY transformers/ transformers/
-RUN apt-get update
-RUN apt-get install -y build-essential
+RUN apt-get update && \
+    apt-get install -y build-essential
 RUN cd transformers/ && \
     python3 -m pip install --no-cache-dir . && \
     python3 -m pip install --no-cache-dir -r examples/requirements.txt


### PR DESCRIPTION
I was getting 404s for some packages before inserting this line.