### PR TITLE
Glue score hyperparameters and arguements for nvbert models

### DIFF
--- a/nvidia-bert/model_evaluation.md
+++ b/nvidia-bert/model_evaluation.md
@@ -7,3 +7,26 @@ python convert_checkpoint.py /workspace/checkpoints/<ort_pretrained_checkpoint> 
 ```
 
 Use the saved checkpoint created from above script for finetuning as described by [NVIDIA](https://github.com/NVIDIA/DeepLearningExamples/tree/96ff411ce84e679514947abe644d975a23867990/PyTorch/LanguageModeling/BERT#fine-tuning).
+
+Hyper-parameters and arguements to run glue scores:
+```
+--task_name: 'MNLI',
+--do_train: '',
+--train_batch_size: 2,
+--do_eval: '',
+--eval_batch_size: 8,
+--do_lower_case: '',
+--data_dir: '/workspace/bert/data/glue/MNLI',
+--bert_model: 'bert-large-uncased',
+--seed: 2,
+--init_checkpoint:'checkpoints/DLE_BERT_FP16_PyT_LAMB_92_hard_scaling_node.pt',
+--warmup_proportion: 0.1,
+--max_seq_length: 128,
+--learning_rate: 3e-5,
+--num_train_epochs: 3,
+--max_steps: -1.0,
+--vocab_file : '/workspace/bert/data/uncased_L-24_H-1024_A-16/vocab.txt',
+--config_file : '/workspace/bert/bert_config.json',
+--output_dir: 'output/MNLI',
+--fp16 : '',
+```


### PR DESCRIPTION
Glue score hyperparameters and arguments for nvbert models. With these hyper-parameters. The MNLI scores obtained for  [DLE_BERT_FP16_PyT_LAMB_92_hard_scaling_node.pt](https://ngc.nvidia.com/catalog/models/nvidia:bertpyt_fp16) are as follows:

Matched Accuracy for MNLI: 0.8499
Mismatched Accuracy for MNLI: 0.8519
