### PR TITLE
Update dependencies in dockerfile

### DIFF
--- a/nvidia-bert/docker/Dockerfile
+++ b/nvidia-bert/docker/Dockerfile
@@ -3,7 +3,8 @@
 FROM mcr.microsoft.com/azureml/onnxruntime-training:0.1-rc2-openmpi4.0-cuda10.2-cudnn7.6-nccl2.7.6
 
 # install nvidia run script dependencies
-RUN apt-get install -y git &&\
+RUN apt-get -y update &&\
+    apt-get install -y git &&\
     pip install --no-cache-dir \
     tqdm boto3 requests six ipdb \
     h5py html2text nltk progressbar \


### PR DESCRIPTION
apt-get update is missing (therefore not updating to latest version) when fixing docker image security vulnerabilities. See https://github.com/microsoft/onnxruntime/blob/master/dockerfiles/Dockerfile.training#L23