### PR TITLE
delete pytorch path in huggingface-transformers examples

### DIFF
--- a/huggingface/azureml/hf-ort.py
+++ b/huggingface/azureml/hf-ort.py
@@ -13,7 +13,7 @@ from azureml.core.compute_target import ComputeTargetException
 from azureml.core import ScriptRunConfig
 from azureml.core.runconfig import PyTorchConfiguration
 
-TRAINER_DIR = '../../huggingface-transformers/examples/pytorch'
+TRAINER_DIR = '../../huggingface-transformers/examples'
 
 MODEL_BATCHSIZE_DICT = {
     "bert-large" : '8',


### PR DESCRIPTION
in submodule [huggingface-transformers @ 430e9f3](https://github.com/microsoft/huggingface-transformers/tree/430e9f325aa2a0e7a4854b2c2842b46a2f83e697), pytorch path was deleted. So I fixed the path.

