### PR TITLE
flip contiguous_gradients flag

### DIFF
--- a/huggingface/script/ds_config_zero_1.json
+++ b/huggingface/script/ds_config_zero_1.json
@@ -14,7 +14,7 @@
                 "overlap_comm": true,
                 "reduce_scatter": true,
                 "reduce_bucket_size": 2e8,
-                "contiguous_gradients": true,
+                "contiguous_gradients": false,
                 "cpu_offload": false
         },
     


### PR DESCRIPTION
We found turning contiguous_gradients flag to false improves performance for all models. Deepspeed folks has confirmed this flag is important for large models but should not make a difference for models that fits base pytorch.