### PR TITLE
Dockerfile change to align with torch_ort

### DIFF
--- a/huggingface/docker/Dockerfile
+++ b/huggingface/docker/Dockerfile
@@ -25,11 +25,11 @@ RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 RUN pip install --upgrade pip
 
 # PyTorch
-RUN pip install onnx ninja
+RUN pip install onnx==1.9.0 ninja
 RUN pip install torch==1.9.0+cu111 torchvision==0.10.0+cu111 torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
 
 # ORT Module
-RUN pip install onnxruntime-training==1.8.1 -f https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_stable_torch190.cu111.html
+RUN pip install onnxruntime-training==1.8.1 -f https://download.onnxruntime.ai/onnxruntime_stable_torch190.cu111.html
 
 RUN pip install torch-ort
 RUN python -m torch_ort.configure

--- a/huggingface/docker/Dockerfile
+++ b/huggingface/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 RUN pip install --upgrade pip
 
 # PyTorch
+# pin onnx==1.9.0 to align with torch_ort dockerfile, otherwise AssertionError
 RUN pip install onnx==1.9.0 ninja
 RUN pip install torch==1.9.0+cu111 torchvision==0.10.0+cu111 torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
 

--- a/huggingface/docker/Dockerfile-10.2
+++ b/huggingface/docker/Dockerfile-10.2
@@ -25,11 +25,11 @@ RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 RUN pip install --upgrade pip
 
 # PyTorch
-RUN pip install onnx ninja
+RUN pip install onnx==1.9.0 ninja
 RUN pip install torch==1.9.0+cu102 torchvision==0.10.0+cu102 torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
 
 # ORT Module
-RUN pip install onnxruntime-training==1.8.1 -f https://onnxruntimepackages.z14.web.core.windows.net/onnxruntime_stable_torch190.cu102.html
+RUN pip install onnxruntime-training==1.8.1 -f https://download.onnxruntime.ai/onnxruntime_stable_torch190.cu102.html
 
 RUN pip install torch-ort
 RUN python -m torch_ort.configure

--- a/huggingface/docker/Dockerfile-10.2
+++ b/huggingface/docker/Dockerfile-10.2
@@ -25,6 +25,7 @@ RUN update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 RUN pip install --upgrade pip
 
 # PyTorch
+# pin onnx==1.9.0 to align with torch_ort dockerfile, otherwise AssertionError
 RUN pip install onnx==1.9.0 ninja
 RUN pip install torch==1.9.0+cu102 torchvision==0.10.0+cu102 torchaudio==0.9.0 -f https://download.pytorch.org/whl/torch_stable.html
 


### PR DESCRIPTION
Previous version of dockerfile will lead to assertion error in onnxruntime in several models. 
Aligning with https://github.com/pytorch/ort/blob/main/docker/Dockerfile.ort-torch190-onnxruntime181-cu111-cudnn8-devel-ubuntu18.04
Verified on all models in azureml