### PR TITLE
Commenting out RoBERTa & DeBERTa to prevent models from being run until issues are resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ ONNX Runtime for PyTorch gives you the ability to accelerate training of large t
 
 This repo has examples for using [ONNX Runtime](https://github.com/microsoft/onnxruntime) (ORT) for accelerating training of [Transformer](https://arxiv.org/abs/1706.03762) models. These examples focus on large scale model training and achieving the best performance in [Azure Machine Learning service](https://azure.microsoft.com/en-us/services/machine-learning/). ONNX Runtime has the capability to train existing PyTorch models (implemented using `torch.nn.Module`) through its optimized backend. The examples in this repo demonstrate how `ORTModule` can be used to switch the training backend. 
 
-**The old ORTTrainer API is no longer supported. Examples for ORTTrainer has been moved under [/orttrainer](/orttrainer).**
-
 ## Examples
 
 Outline the examples in the repository.

--- a/huggingface/README.md
+++ b/huggingface/README.md
@@ -118,3 +118,10 @@ The issue is most likely caused by hitting a HW limitation on the target, this c
   ```
 python hf-ort.py --hf_model bart-large --run_config pt-fp16 --process_count 1 --local_run --model_batchsize 1 --max_steps 20
 ```
+
+## Notes
+RoBERTa & DeBERTa currently decommissioned from the hf-ort.py script because of unresolved issues. 
+
+RoBERTa currently requires ORT >= 1.12.0 according to this issue ([#11268](https://github.com/microsoft/onnxruntime/issues/11268)) which was resolved in ORT 1.12.0. However, running with ORT 1.12.0 with the PTCA Docker container and on the specified machine for benchmarking causes this issue ([#12312](https://github.com/microsoft/onnxruntime/issues/11268)).
+
+DeBERTa has the following unresolved issues when using Optimum's ORTTrainer: [#15](https://github.com/microsoft/onnx-converters-private/issues/15) and [#305](https://github.com/huggingface/optimum/issues/305)

--- a/huggingface/README.md
+++ b/huggingface/README.md
@@ -9,7 +9,7 @@ This example uses ORTModule to fine-tune several popular [HuggingFace](https://h
 git clone https://github.com/microsoft/onnxruntime-training-examples.git
 cd onnxruntime-training-examples
 git submodule update --init --recursive
-git submodule foreach git pull origin master
+git submodule foreach git pull origin main
 ```
 2. Make sure python 3.8+ is installed
 

--- a/huggingface/README.md
+++ b/huggingface/README.md
@@ -120,8 +120,6 @@ python hf-ort.py --hf_model bart-large --run_config pt-fp16 --process_count 1 --
 ```
 
 ## Notes
-RoBERTa & DeBERTa currently decommissioned from the hf-ort.py script because of unresolved issues. 
-
-RoBERTa currently requires ORT >= 1.12.0 according to this issue ([#11268](https://github.com/microsoft/onnxruntime/issues/11268)) which was resolved in ORT 1.12.0. However, running with ORT 1.12.0 with the PTCA Docker container and on the specified machine for benchmarking causes this issue ([#12312](https://github.com/microsoft/onnxruntime/issues/11268)).
+DeBERTa is currently decommissioned from the hf-ort.py script because of unresolved issues. 
 
 DeBERTa has the following unresolved issues when using Optimum's ORTTrainer: [#15](https://github.com/microsoft/onnx-converters-private/issues/15) and [#305](https://github.com/huggingface/optimum/issues/305)

--- a/huggingface/docker/Dockerfile
+++ b/huggingface/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azureml/aifx/stable-ubuntu2004-cu115-py38-torch1110
+FROM ptebic.azurecr.io/internal/azureml/aifx/stable-ubuntu2004-cu116-py38-torch1120
 ENV DISABLE_MLFLOW_INTEGRATION TRUE
 
 RUN pip3 install accelerate

--- a/huggingface/script/hf-ort.py
+++ b/huggingface/script/hf-ort.py
@@ -18,11 +18,8 @@ from azureml.core.runconfig import PyTorchConfiguration
 # as well as: https://github.com/microsoft/onnx-converters-private/issues/15
 # DeBERTa code commented out for now
 
-# NOTE: RoBERTa currently does not run because it requires ORT==1.12.0
-# and ORT==1.12.0 is running into issues with the Optimum scripts.
+# NOTE: RoBERTa requires ORT==1.12.0
 # see: https://github.com/microsoft/onnxruntime/issues/11268
-# as well as: https://github.com/microsoft/onnxruntime/issues/12312
-# RoBERTa code commented out for now
 
 OPTIMUM_TRAINER_DIR = '../../optimum/examples/onnxruntime/training'
 TRANSFORMERS_TRAINER_DIR = '../../transformers/examples/pytorch'
@@ -79,7 +76,7 @@ parser.add_argument("--gpu_cluster_name",
 parser.add_argument("--hf_model",
                         help="Huggingface models to run", type=str, required=True,
                         # choices=['bert-large', 'distilbert-base', 'gpt2', 'bart-large', 't5-large', 'deberta-v2-xxlarge', 'roberta-large'])
-                        choices=['bert-large', 'distilbert-base', 'gpt2', 'bart-large', 't5-large'])
+                        choices=['bert-large', 'distilbert-base', 'gpt2', 'bart-large', 't5-large', 'roberta-large'])
 
 parser.add_argument("--run_config",
                         help="Run configuration indicating pytorch or ort, deepspeed stage", type=str, required=True,

--- a/huggingface/script/hf-ort.py
+++ b/huggingface/script/hf-ort.py
@@ -13,6 +13,11 @@ from azureml.core.compute_target import ComputeTargetException
 from azureml.core import ScriptRunConfig
 from azureml.core.runconfig import PyTorchConfiguration
 
+# NOTE: DeBERTa currently does not run with the Optimum ORT wrapper
+# see: https://github.com/huggingface/optimum/issues/305
+# as well as: https://github.com/microsoft/onnx-converters-private/issues/15
+# DeBERTa code commented out for now
+
 OPTIMUM_TRAINER_DIR = '../../optimum/examples/onnxruntime/training'
 TRANSFORMERS_TRAINER_DIR = '../../transformers/examples/pytorch'
 
@@ -22,7 +27,7 @@ MODEL_BATCHSIZE_DICT = {
     "gpt2" : '8',
     "bart-large" : '16',
     "t5-large" : '8',
-    "deberta-v2-xxlarge" : '4',
+    # "deberta-v2-xxlarge" : '4',
     "roberta-large" : '16'
 }
 
@@ -32,7 +37,7 @@ RUN_SCRIPT_DICT= {
     "gpt2" : ['run_clm.py'],
     "bart-large" : ['run_translation.py'],
     "t5-large" : ['run_translation.py'],
-    "deberta-v2-xxlarge" : ['run_glue.py'],
+    # "deberta-v2-xxlarge" : ['run_glue.py'],
     "roberta-large" : ['run_qa.py', 'trainer_qa.py', 'utils_qa.py']
 }
 
@@ -42,7 +47,7 @@ RUN_SCRIPT_DIR_DICT= {
     "gpt2" : 'language-modeling',
     "bart-large" : 'translation',
     "t5-large" : 'translation',
-    "deberta-v2-xxlarge" : 'text-classification',
+    # "deberta-v2-xxlarge" : 'text-classification',
     "roberta-large" : 'question-answering'
 }
 
@@ -67,7 +72,8 @@ parser.add_argument("--gpu_cluster_name",
 
 parser.add_argument("--hf_model",
                         help="Huggingface models to run", type=str, required=True,
-                        choices=['bert-large', 'distilbert-base', 'gpt2', 'bart-large', 't5-large', 'deberta-v2-xxlarge', 'roberta-large'])
+                        # choices=['bert-large', 'distilbert-base', 'gpt2', 'bart-large', 't5-large', 'deberta-v2-xxlarge', 'roberta-large'])
+                        choices=['bert-large', 'distilbert-base', 'gpt2', 'bart-large', 't5-large', 'roberta-large'])
 
 parser.add_argument("--run_config",
                         help="Run configuration indicating pytorch or ort, deepspeed stage", type=str, required=True,

--- a/huggingface/script/hf-ort.py
+++ b/huggingface/script/hf-ort.py
@@ -18,6 +18,12 @@ from azureml.core.runconfig import PyTorchConfiguration
 # as well as: https://github.com/microsoft/onnx-converters-private/issues/15
 # DeBERTa code commented out for now
 
+# NOTE: RoBERTa currently does not run because it requires ORT==1.12.0
+# and ORT==1.12.0 is running into issues with the Optimum scripts.
+# see: https://github.com/microsoft/onnxruntime/issues/11268
+# as well as: https://github.com/microsoft/onnxruntime/issues/12312
+# RoBERTa code commented out for now
+
 OPTIMUM_TRAINER_DIR = '../../optimum/examples/onnxruntime/training'
 TRANSFORMERS_TRAINER_DIR = '../../transformers/examples/pytorch'
 
@@ -27,7 +33,7 @@ MODEL_BATCHSIZE_DICT = {
     "gpt2" : '8',
     "bart-large" : '16',
     "t5-large" : '8',
-    # "deberta-v2-xxlarge" : '4',
+    "deberta-v2-xxlarge" : '4',
     "roberta-large" : '16'
 }
 
@@ -37,7 +43,7 @@ RUN_SCRIPT_DICT= {
     "gpt2" : ['run_clm.py'],
     "bart-large" : ['run_translation.py'],
     "t5-large" : ['run_translation.py'],
-    # "deberta-v2-xxlarge" : ['run_glue.py'],
+    "deberta-v2-xxlarge" : ['run_glue.py'],
     "roberta-large" : ['run_qa.py', 'trainer_qa.py', 'utils_qa.py']
 }
 
@@ -47,7 +53,7 @@ RUN_SCRIPT_DIR_DICT= {
     "gpt2" : 'language-modeling',
     "bart-large" : 'translation',
     "t5-large" : 'translation',
-    # "deberta-v2-xxlarge" : 'text-classification',
+    "deberta-v2-xxlarge" : 'text-classification',
     "roberta-large" : 'question-answering'
 }
 
@@ -73,7 +79,7 @@ parser.add_argument("--gpu_cluster_name",
 parser.add_argument("--hf_model",
                         help="Huggingface models to run", type=str, required=True,
                         # choices=['bert-large', 'distilbert-base', 'gpt2', 'bart-large', 't5-large', 'deberta-v2-xxlarge', 'roberta-large'])
-                        choices=['bert-large', 'distilbert-base', 'gpt2', 'bart-large', 't5-large', 'roberta-large'])
+                        choices=['bert-large', 'distilbert-base', 'gpt2', 'bart-large', 't5-large'])
 
 parser.add_argument("--run_config",
                         help="Run configuration indicating pytorch or ort, deepspeed stage", type=str, required=True,


### PR DESCRIPTION
## changes made
Commented out a line so that trying to run RoBERTa or DeBERTa causes an error -- tried to comment out as few lines as possible so that adding roBERTa + deBERTa support back in is easier in the future.

Not sure if this should also be mentioned in the README.


## background / explanation
RoBERTa currently requires ORT >= 1.12.0 according to this issue ([#11268](https://github.com/microsoft/onnxruntime/issues/11268)) which was resolved in ORT 1.12.0. However, running with ORT 1.12.0 with the PTCA Docker container and on the specified machine for benchmarking causes this issue ([#12312](https://github.com/microsoft/onnxruntime/issues/11268)).

DeBERTa has the following unresolved issues when using Optimum's ORTTrainer: [#15](https://github.com/microsoft/onnx-converters-private/issues/15) and [#305](https://github.com/huggingface/optimum/issues/305)