### PR TITLE
Decommission RoBERTa & DeBERTa; amend README's

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ ONNX Runtime for PyTorch gives you the ability to accelerate training of large t
 
 This repo has examples for using [ONNX Runtime](https://github.com/microsoft/onnxruntime) (ORT) for accelerating training of [Transformer](https://arxiv.org/abs/1706.03762) models. These examples focus on large scale model training and achieving the best performance in [Azure Machine Learning service](https://azure.microsoft.com/en-us/services/machine-learning/). ONNX Runtime has the capability to train existing PyTorch models (implemented using `torch.nn.Module`) through its optimized backend. The examples in this repo demonstrate how `ORTModule` can be used to switch the training backend. 
 
-**The old ORTTrainer API is no longer supported. Examples for ORTTrainer has been moved under [/orttrainer](/orttrainer).**
-
 ## Examples
 
 Outline the examples in the repository.

--- a/huggingface/README.md
+++ b/huggingface/README.md
@@ -118,3 +118,10 @@ The issue is most likely caused by hitting a HW limitation on the target, this c
   ```
 python hf-ort.py --hf_model bart-large --run_config pt-fp16 --process_count 1 --local_run --model_batchsize 1 --max_steps 20
 ```
+
+## Notes
+RoBERTa & DeBERTa currently decommissioned from the hf-ort.py script because of unresolved issues.
+
+RoBERTa currently requires ORT >= 1.12.0 according to this issue ([#11268](https://github.com/microsoft/onnxruntime/issues/11268)) which was resolved in ORT 1.12.0. However, running with ORT 1.12.0 with the PTCA Docker container and on the specified machine for benchmarking causes this issue ([#12312](https://github.com/microsoft/onnxruntime/issues/12312)).
+
+DeBERTa has the following unresolved issues when using Optimum's ORTTrainer: [#15](https://github.com/microsoft/onnx-converters-private/issues/15) and [#305](https://github.com/huggingface/optimum/issues/305)

--- a/huggingface/README.md
+++ b/huggingface/README.md
@@ -9,7 +9,7 @@ This example uses ORTModule to fine-tune several popular [HuggingFace](https://h
 git clone https://github.com/microsoft/onnxruntime-training-examples.git
 cd onnxruntime-training-examples
 git submodule update --init --recursive
-git submodule foreach git pull origin master
+git submodule foreach git pull origin main
 ```
 2. Make sure python 3.8+ is installed
 

--- a/huggingface/script/hf-ort.py
+++ b/huggingface/script/hf-ort.py
@@ -13,6 +13,17 @@ from azureml.core.compute_target import ComputeTargetException
 from azureml.core import ScriptRunConfig
 from azureml.core.runconfig import PyTorchConfiguration
 
+# NOTE: DeBERTa currently does not run with the Optimum ORT wrapper
+# see: https://github.com/huggingface/optimum/issues/305
+# as well as: https://github.com/microsoft/onnx-converters-private/issues/15
+# DeBERTa code commented out for now
+
+# NOTE: RoBERTa currently does not run because it requires ORT==1.12.0
+# and ORT==1.12.0 is running into issues with the Optimum scripts.
+# see: https://github.com/microsoft/onnxruntime/issues/11268
+# as well as: https://github.com/microsoft/onnxruntime/issues/12312
+# RoBERTa code commented out for now
+
 OPTIMUM_TRAINER_DIR = '../../optimum/examples/onnxruntime/training'
 TRANSFORMERS_TRAINER_DIR = '../../transformers/examples/pytorch'
 
@@ -67,7 +78,8 @@ parser.add_argument("--gpu_cluster_name",
 
 parser.add_argument("--hf_model",
                         help="Huggingface models to run", type=str, required=True,
-                        choices=['bert-large', 'distilbert-base', 'gpt2', 'bart-large', 't5-large', 'deberta-v2-xxlarge', 'roberta-large'])
+                        # choices=['bert-large', 'distilbert-base', 'gpt2', 'bart-large', 't5-large', 'deberta-v2-xxlarge', 'roberta-large'])
+                        choices=['bert-large', 'distilbert-base', 'gpt2', 'bart-large', 't5-large'])
 
 parser.add_argument("--run_config",
                         help="Run configuration indicating pytorch or ort, deepspeed stage", type=str, required=True,


### PR DESCRIPTION
Changes in this PR:
* commented out roberta and deberta
* documented reasons for decommission in the README and the code comment
* fixed README command that was causing issues for users
* removed reference to a deleted folder (ORTTrainer)