### PR TITLE
Update installation instructions for iOS On-Device-Training example

### DIFF
--- a/on_device_training/mobile/ios/README.md
+++ b/on_device_training/mobile/ios/README.md
@@ -40,6 +40,12 @@ From this directory, run:
 pip install -r requirements.txt
 ```
 
+Then run the following to install onnxruntime-training pip package:
+
+```bash
+pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training-cpu
+```
+
 ### Generate Artifacts
 [Artifacts generation](./artifacts_gen.py) script downloads the model from huggingface and creates the training artifacts in `MyVoice/artifacts`. 
 

--- a/on_device_training/mobile/ios/requirements.txt
+++ b/on_device_training/mobile/ios/requirements.txt
@@ -1,9 +1,15 @@
 datasets==2.14.0
 numpy==1.23.5
 onnx==1.14.0
-onnxruntime-training==1.16.0
 scipy==1.11.1
 torch==2.0.1
 transformers==4.36.0
 librosa==0.10.0.post2
 soundfile==0.12.1
+cerberus
+flatbuffers
+h5py
+packaging
+protobuf
+sympy
+setuptools>=41.4.0


### PR DESCRIPTION
fix for issue #178 with updated installation instructions for onnxruntime-training.