### PR TITLE
Updated installation instructions for on-device training package

### DIFF
--- a/on_device_training/desktop/csharp/masked_language_modeling/requirements.txt
+++ b/on_device_training/desktop/csharp/masked_language_modeling/requirements.txt
@@ -1,0 +1,4 @@
+numpy==1.26.3
+torch
+transformers
+datasets

--- a/on_device_training/desktop/python/mnist.ipynb
+++ b/on_device_training/desktop/python/mnist.ipynb
@@ -26,9 +26,7 @@
    "source": [
     "#### Importing libraries\n",
     "\n",
-    "Make sure to install onnxruntime-training's nightly version.\n",
-    "\n",
-    "```pip install onnxruntime-training```"
+    "Make sure to install onnxruntime-training's nightly version. Check [our website (click Optimize Training)](https://onnxruntime.ai/getting-started) for instructions on downloading the onnxruntime-training nightly Python package."
    ]
   },
   {

--- a/on_device_training/web/offline-step/README.md
+++ b/on_device_training/web/offline-step/README.md
@@ -5,6 +5,7 @@ This step is the same regardless of the method used to import the ONNXRuntime-we
 ## Set-up
 
 Install dependencies. This step requires onnxruntime-training-cpu>=1.17.0. 
+Check [our website (click Optimize Training)](https://onnxruntime.ai/getting-started) for instructions on downloading the onnxruntime-training nightly Python package.
 ```
 pip install -r requirements.txt
 pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ORT/pypi/simple/ onnxruntime-training-cpu


### PR DESCRIPTION
To reflect the updated installation instructions for installing onnxruntime for training. Also adds requirements.txt for mobilebert example

Addresses [ONNXRuntime issue #21149](https://github.com/microsoft/onnxruntime/issues/21149)